### PR TITLE
Fix typo in agent_definition.md

### DIFF
--- a/agent_builder/agent_definition.md
+++ b/agent_builder/agent_definition.md
@@ -28,5 +28,5 @@ gpt-4-1106-preview
 - Retrieval
 
 # Files
-- READE.md
+- README.md
 - OpenAI_Documentation.md


### PR DESCRIPTION
Fixed typo for README.md file name from agent definition