### PR TITLE
Attempt to prevent reprovisioning of existing agents and the reuploading of files

### DIFF
--- a/agent_builder/agents/Autonomous Swarm Agent Builder/settings.json
+++ b/agent_builder/agents/Autonomous Swarm Agent Builder/settings.json
@@ -1,0 +1,6 @@
+{
+  "model": "gpt-4-1106-preview",
+  "description": "Foundation Swarm Builder",
+  "tools": [{ "type": "code_interpreter" }],
+  "metadata": {}
+}

--- a/agent_builder/create.py
+++ b/agent_builder/create.py
@@ -14,10 +14,10 @@ client = OpenAI(api_key=api_key)
 if not os.path.exists(agents_path) or not os.path.isdir(agents_path) or not os.listdir(agents_path):
     raise ValueError('The "agents" folder is missing, not a directory, or empty.')
 
-existing_assitstants = {}
+existing_assistants = {}
 
 for assistant in  client.beta.assistants.list(limit=100):
-    existing_assitstants[assistant.name] = assistant
+    existing_assistants[assistant.name] = assistant
 
 
 # Iterate over each folder inside the 'agents' folder
@@ -27,8 +27,8 @@ for agent_name in os.listdir(agents_path):
     existing_files = {}
     requested_files = []
     existing_agent = {}
-    if agent_name in existing_assitstants:
-        existing_agent = existing_assitstants[agent_name]    
+    if agent_name in existing_assistants:
+        existing_agent = existing_assistants[agent_name]    
         for file_id in existing_agent.file_ids:
             existing_file = client.files.retrieve(file_id=file_id)
             existing_files[existing_file.filename] = existing_file

--- a/agent_builder/create.py
+++ b/agent_builder/create.py
@@ -14,9 +14,26 @@ client = OpenAI(api_key=api_key)
 if not os.path.exists(agents_path) or not os.path.isdir(agents_path) or not os.listdir(agents_path):
     raise ValueError('The "agents" folder is missing, not a directory, or empty.')
 
+existing_assitstants = {}
+
+for assistant in  client.beta.assistants.list(limit=100):
+    existing_assitstants[assistant.name] = assistant
+
+
 # Iterate over each folder inside the 'agents' folder
 for agent_name in os.listdir(agents_path):
     agent_folder = os.path.join(agents_path, agent_name)
+
+    existing_files = {}
+    requested_files = []
+    existing_agent = {}
+    if agent_name in existing_assitstants:
+        existing_agent = existing_assitstants[agent_name]    
+        for file_id in existing_agent.file_ids:
+            existing_file = client.files.retrieve(file_id=file_id)
+            existing_files[existing_file.filename] = existing_file
+
+
     if os.path.isdir(agent_folder):
         # Read contents from the 'instructions.md' file
         instructions = ''
@@ -30,11 +47,16 @@ for agent_name in os.listdir(agents_path):
         files_folder = os.path.join(agent_folder, 'files')
         if os.path.isdir(files_folder):
             for filename in os.listdir(files_folder):
-                file_path = os.path.join(files_folder, filename)
-                with open(file_path, 'rb') as file_data:
-                    # Upload each file to OpenAI
-                    file_object = client.files.create(file=file_data, purpose='assistants')
-                    files.append({"name": filename, "id": file_object.id})
+                requested_files.append(filename)
+                # Doesn't handle if file has been modified
+                if filename not in existing_files:
+                    file_path = os.path.join(files_folder, filename)
+                    with open(file_path, 'rb') as file_data:
+                        # Upload each file to OpenAI
+                        file_object = client.files.create(file=file_data, purpose='assistants')
+                        files.append({"name": filename, "id": file_object.id})
+
+        model = 'gpt-4-1106-preview'          
 
         print(agent_name)
         print("")
@@ -43,17 +65,54 @@ for agent_name in os.listdir(agents_path):
             print("")
             print(f"Files: {list(map(lambda x: x['name'], files))}")
 
-        create_params = {
-            "name": agent_name,
-            "instructions": instructions,
-            "model": 'gpt-4-1106-preview',
-            "tools": [{'type': 'code_interpreter'}, {'type': 'retrieval'}]
-        }
-        
-        # Only include 'file_ids' if there are files
-        if files:
-            create_params['file_ids'] = list(map(lambda x: x['id'], files))
+        assistant={}
 
-        # Create the assistant using the uploaded file IDs if files exist
-        assistant = client.beta.assistants.create(**create_params)
+        if existing_agent:
+            print(f"{agent_name} already exists... validating properties")
+            update_model = existing_agent.model != model
+            update_instructions = existing_agent.instructions != instructions
+            #need to evaluate tools
+            
+            update_params = {}
+            
+            requested_files_set = set(requested_files)
+            existing_files_set = set(existing_files.keys())
+
+            if update_model:
+                update_params["model"] = model
+            if update_instructions:
+                update_params["instructions"] = instructions
+            if files or requested_files_set != existing_files_set:
+               retained_set = existing_files_set.intersection(requested_files_set)
+               all_file_ids = []
+               for key in retained_set:
+                   all_file_ids.append(existing_files[key].id)
+               all_file_ids += list(map(lambda x: x['id'], files))
+               update_params['file_ids'] = all_file_ids
+               if not any( tool.type == "retrieval" for tool in existing_agent.tools):
+                  update_params['tools'] = existing_agent.tools
+                  update_params['tools'].append({'type': 'retrieval'})
+
+            if len(update_params) != 0:
+                print(f"Updating {agent_name}'s { ','.join(update_params.keys()) }") 
+                update_params['assistant_id'] = existing_agent.id
+                assistant = client.beta.assistants.update(**update_params)
+            else:
+              print(f"{agent_name} is up to date")         
+        else:        
+
+            create_params = {
+                "name": agent_name,
+                "instructions": instructions,
+                "model": model,
+                "tools": [{'type': 'code_interpreter'}]
+            }
+
+            # Only include 'file_ids' if there are files
+            if files:
+                create_params['tools'].append({'type': 'retrieval'})
+                create_params['file_ids'] = list(map(lambda x: x['id'], files))
+
+            # Create the assistant using the uploaded file IDs if files exist
+            assistant = client.beta.assistants.create(**create_params)
         print("***********************************************")


### PR DESCRIPTION
Adding logic to prevent the duplication of existing agents, and to prevent existing files from being reuploaded.
The script still needs tool integration for agents.

In order to allow for retrieval file modification either the contents of the files can be compared using https://platform.openai.com/docs/api-reference/files/retrieve-contents , or it could be required that whenever a retrieval file needs to be updated its file name should also be updated.
