### PR TITLE
centralise client setup and access of api key

### DIFF
--- a/agents/agent_builder/create.py
+++ b/agents/agent_builder/create.py
@@ -1,15 +1,9 @@
-from openai import OpenAI
 import os
 import json
-import dotenv
-dotenv.load_dotenv()
+from shared.openai_config import get_openai_client
 
 agents_path = 'agents'
-api_key = os.getenv('OPENAI_API_KEY')
-if api_key is None:
-    raise ValueError('The OPENAI_API_KEY environment variable is not set.')
-
-client = OpenAI(api_key=api_key)
+client = get_openai_client()
 
 # Check if the 'agents' folder is empty or doesn't exist
 if not os.path.exists(agents_path) or not os.path.isdir(agents_path) or not os.listdir(agents_path):

--- a/agents/tool_maker/assistant_manager.py
+++ b/agents/tool_maker/assistant_manager.py
@@ -101,11 +101,9 @@ class AssistantManager:
 
 
 if __name__ == "__main__":
-    from openai import OpenAI
-    import os
-
-    apikey = os.getenv("OPENAI_API_KEY")
-    client = OpenAI(api_key=apikey)
+    from shared.openai_config import get_openai_client
+    client = get_openai_client()
+    
     assistant_manager = AssistantManager(client=client)
     assistant = assistant_manager.get_assistant()
     print(assistant)

--- a/agents/tool_maker/tool_creator.py
+++ b/agents/tool_maker/tool_creator.py
@@ -6,9 +6,9 @@ import json
 import os
 
 from shared.utils import chat as chat_loop
+from shared.openai_config import get_openai_client 
 
-from openai import OpenAI
-client = OpenAI() # be sure to set your OPENAI_API_KEY environment variable
+client = get_openai_client()
 
 def create_tool_creator(assistant_details):
     # create the assistant

--- a/agents/tool_maker/tool_user.py
+++ b/agents/tool_maker/tool_user.py
@@ -6,9 +6,9 @@ import os
 import json
 
 from shared.utils import chat as chat_loop
+from shared.openai_config import get_openai_client
 
-from openai import OpenAI
-client = OpenAI() # be sure to set your OPENAI_API_KEY environment variable
+client = get_openai_client() 
 
 def create_tool_user(assistant_details):
     # create the assistant

--- a/agents/tool_maker/unit_manager.py
+++ b/agents/tool_maker/unit_manager.py
@@ -27,13 +27,8 @@ class Unit:
 
 
 if __name__ == "__main__":
-    import os
-    from openai import OpenAI
-
-    api_key = os.getenv("OPENAI_API_KEY")
-    if api_key is None:
-        raise ValueError("The OPENAI_API_KEY environment variable is not set.")
-    client = OpenAI(api_key=api_key)
+    from shared.openai_config import get_openai_client
+    client = get_openai_client()
 
     unit = Unit(client=client)
     unit.chat()

--- a/shared/agent_connector/connect.py
+++ b/shared/agent_connector/connect.py
@@ -1,18 +1,12 @@
 import yaml
-from openai import OpenAI
+from shared.openai_config import get_openai_client 
 import os
-import dotenv
-dotenv.load_dotenv()
 import queue as queueModule
 import time
 import threading
 
 agents_path = 'agents'
-api_key = os.getenv('OPENAI_API_KEY')
-if api_key is None:
-    raise ValueError('The OPENAI_API_KEY environment variable is not set.')
-
-client = OpenAI(api_key=api_key)
+client = get_openai_client()
 
 # Get the directory name of the current script
 script_dir = os.path.dirname(os.path.abspath(__file__))

--- a/shared/openai_config.py
+++ b/shared/openai_config.py
@@ -1,11 +1,6 @@
-import os
-import dotenv
+from shared.settings import Settings
 from openai import OpenAI
 
-dotenv.load_dotenv()
-
 def get_openai_client():
-    api_key = os.getenv('OPENAI_API_KEY')
-    if api_key is None:
-        raise ValueError('The OPENAI_API_KEY environment variable is not set.')
-    return OpenAI(api_key=api_key)
+    settings = Settings()
+    return OpenAI(api_key=settings.OPENAI_API_KEY)

--- a/shared/openai_config.py
+++ b/shared/openai_config.py
@@ -1,0 +1,11 @@
+import os
+import dotenv
+from openai import OpenAI
+
+dotenv.load_dotenv()
+
+def get_openai_client():
+    api_key = os.getenv('OPENAI_API_KEY')
+    if api_key is None:
+        raise ValueError('The OPENAI_API_KEY environment variable is not set.')
+    return OpenAI(api_key=api_key)

--- a/shared/settings.py
+++ b/shared/settings.py
@@ -1,0 +1,8 @@
+from pydantic import BaseSettings
+
+class Settings(BaseSettings):
+    OPENAI_API_KEY: str  
+
+    class Config:
+        env_file = '.env'
+        env_file_encoding = 'utf-8'

--- a/shared/settings.py
+++ b/shared/settings.py
@@ -1,4 +1,4 @@
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     OPENAI_API_KEY: str  


### PR DESCRIPTION
## Overview
I've refactored the OpenAI client initialisation into a single module to clean up the codebase and make it more DRY.

Following this (if people would like), I want to add a mock OpenAI client (which can be used if a specific env var is set). This addition will enable contributors to test the project more easily and without a valid API key. The centralised client setup change should make adding this mock client more straightforward.

## PR Feedback
I've introduced pydantic-settings for environment variable management (suggsted by @gruckion - see commit: [link](https://github.com/daveshap/OpenAI_Agent_Swarm/pull/76/commits/29daff94ee766201731e0e9df30ab939b7ecea00)). I'm open to any feedback or concerns regarding the introduction of this new library (requirements.txt soon?). 

Pydantic-settings streamlines our setup and eases the addition of APIs like Pinecone in the future, a point @daveshap touched on in his recent video about enhancing agent communication.