### PR TITLE
Fix README Image Display

### DIFF
--- a/agents/tool_maker/README.md
+++ b/agents/tool_maker/README.md
@@ -50,4 +50,4 @@ Note: Remember to prioritize user requirements and emphasize clear communication
 ```
 
 ## Flowchart
-![[imgs/flow.png]]
+![Flow Diagram](imgs/flow.png)


### PR DESCRIPTION
Corrected the Markdown syntax for displaying the 'flow.png' image in the README. Changed from `![[imgs/flow.png]]` to `![Flow Diagram](imgs/flow.png)` to ensure it displays properly on the GitHub webpage.
