### PR TITLE
Fix: Correct markdown for DEMO.png and OpenAI_Tools.PNG in tool_maker…

### DIFF
--- a/agents/tool_maker/README.md
+++ b/agents/tool_maker/README.md
@@ -10,10 +10,11 @@ run the ```unit_manager.py``` file.
 You will be prompted to define a tool for creation. The assistant will then generate an OpenAI tool compatible JSON schema defining the name of the new function, it's description and the input argument schema. It will proceed to add this tool to the current assistant.
 
 (Example)
-![[imgs/DEMO.png]]
+![Example](imgs/DEMO.png)
 
 (Update to assistant on OpenAI servers)
-![[imgs/OpenAI_Tools.png]]
+
+![Update to assistant on OpenAI servers](imgs/OpenAI_Tools.PNG)
 
 ## Assistant Instructions
 


### PR DESCRIPTION
Updated the links for DEMO.png and OpenAI_Tools.PNG in the tool_maker Readme.md file. Previously, the image links were broken due to incorrect markdown and path.