### PR TITLE
Removing Depricated OpenAI API endpoint

### DIFF
--- a/agents/agent_builder/create.py
+++ b/agents/agent_builder/create.py
@@ -136,7 +136,7 @@ class AgentBuilder:
                     create_params['file_ids'] = list(map(lambda x: x['id'], files))
 
                 # Create the assistant using the uploaded file IDs if files exist
-                assistant = self.client.beta.assistants.create(**create_params)
+                #assistant = self.client.beta.assistants.update(**update_params)
             print("***********************************************")
 
     def create_assistants(self):


### PR DESCRIPTION
line 120 in /agents/agent_builder/create.py uses an openai endpoint that appears to be deprecated. I was not able to find any documentation about this, but it caused an unhelpful error message and looks to be unused.

I am currently using bash with windows subsystem for linux, and encountered the issue using the following command

```
python3 -m agents.tool_maker.unit_manager
```

I discovered this on a spinoff project that this project inspired and have tested it with the main repository. commenting it out appears to fix the issue without affecting performance.

### Error message:
```
.local/lib/python3.10/site-packages/openai/_base_client.py", line 980, in _request
    raise self._make_status_error_from_response(err.response) from None
openai.BadRequestError: Error code: 400 - {'error': {'message': "6 validation errors for Request\nbody -> tools\n  instance of Missing expected (type=type_error.arbitrary_type; expected_arbitrary_type=Missing)\nbody -> tools -> 1 -> type\n  unexpected value; permitted: <ToolTypeParam.CODE_INTERPRETER: 'code_interpreter'> (type=value_error.const; given=function; permitted=(<ToolTypeParam.CODE_INTERPRETER: 'code_interpreter'>,))\nbody -> tools -> 1 -> function\n  extra fields not permitted (type=value_error.extra)\nbody -> tools -> 1 -> type\n  unexpected value; permitted: <ToolTypeParam.RETRIEVAL: 'retrieval'> (type=value_error.const; given=function; permitted=(<ToolTypeParam.RETRIEVAL: 'retrieval'>,))\nbody -> tools -> 1 -> function\n  extra fields not permitted (type=value_error.extra)\nbody -> tools -> 1 -> function -> required\n  extra fields not permitted (type=value_error.extra)", 'type': 'invalid_request_error', 'param': None, 'code': None}}
```